### PR TITLE
Libcontainer execution driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ SHELL = /bin/sh
 .SUFFIXES:
 
 osx:
-	go build -v -o hsup ./cmd/hsup
+	godep go build -v -o hsup ./cmd/hsup
 	./build/on_osx.sh

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ echo '{
         "NAME": "CONTENTS"
     },
     "Slug": "sample-slug.tgz",
+    "Stack": "cedar-14",
     "Processes": [
         {
             "Args": ["./web-server", "arg"],

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Where `COMMAND` is on one:
 Example:
 
 ``` sh
-go install
+godep go install ./...
 export DOCKER_HOST=unix:///var/run/docker.sock
 export HEROKU_ACCESS_TOKEN=...
 
@@ -40,7 +40,7 @@ hsup run -d simple -a simple-brandur -- echo "hello"
 Example using a directory:
 
 ```sh
-go install
+godep go install ./...
 export HSUP_CONTROL_DIR=/tmp/supctl
 mkdir -p "$HSUP_CONTROL_DIR"
 echo '{

--- a/WIP.md
+++ b/WIP.md
@@ -42,3 +42,4 @@ Caveats:
 * no privilege dropping, containers still run as root
 * no networking
 * container data is not being garbage collected yet
+* libcontainerDriver.Stop() (probably) doesn't currently work

--- a/WIP.md
+++ b/WIP.md
@@ -41,3 +41,4 @@ Caveats:
 * no support for local slugs
 * no privilege dropping, containers still run as root
 * no networking
+* container data is not being garbage collected yet

--- a/WIP.md
+++ b/WIP.md
@@ -28,15 +28,16 @@ $ godep go build &&
 
 ## libcontainer driver
 
-This is currently in a non-working state with many bugs, but the
-general idea is to handle containerization and subsequent delegation
-to the "abspath" driver:
+It works (with a few caveats listed below), but requires `root` to be used:
 
 ```
-$ export HEROKU_ACCESS_TOKEN=[REDACTED]
-$ export HSUP_APP=[REDACTED]
-$ godep go build &&
-  sudo env HSUP_NEWROOT=tmp/root HSUP_HOSTNAME=whatever HSUP_USER=$(id -nu) \
-  "HEROKU_ACCESS_TOKEN=$HEROKU_ACCESS_TOKEN" \
-  ./hsup run printenv -d libcontainer -a "$HSUP_APP"
+$ godep go install ./... && sudo env HSUP_CONTROL_DIR=/tmp/hspctl \
+  hsup run -d libcontainer '/bin/bash'
 ```
+
+Caveats:
+
+* it must be build with `godep`
+* no support for local slugs
+* no privilege dropping, containers still run as root
+* no networking

--- a/WIP.md
+++ b/WIP.md
@@ -25,3 +25,18 @@ $ godep go build &&
     "HEROKU_ACCESS_TOKEN=$HEROKU_ACCESS_TOKEN" \
     /hsup run printenv -d abspath -a "$HSUP_APP"
 ```
+
+## libcontainer driver
+
+This is currently in a non-working state with many bugs, but the
+general idea is to handle containerization and subsequent delegation
+to the "abspath" driver:
+
+```
+$ export HEROKU_ACCESS_TOKEN=[REDACTED]
+$ export HSUP_APP=[REDACTED]
+$ godep go build &&
+  sudo env HSUP_NEWROOT=tmp/root HSUP_HOSTNAME=whatever HSUP_USER=$(id -nu) \
+  "HEROKU_ACCESS_TOKEN=$HEROKU_ACCESS_TOKEN" \
+  ./hsup run printenv -d libcontainer -a "$HSUP_APP"
+```

--- a/build/in_docker.sh
+++ b/build/in_docker.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd /go/src/github.com/heroku/hsup
-go build -v -o hsup-linux-amd64  ./cmd/hsup
+godep go build -v -o hsup-linux-amd64 ./cmd/hsup

--- a/build/in_docker.sh
+++ b/build/in_docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 cd /go/src/github.com/heroku/hsup
-godep go build -v -o hsup-linux-amd64 ./cmd/hsup
+go build -o godep-linux-amd64 github.com/tools/godep
+./godep-linux-amd64 go build -v -o hsup-linux-amd64 ./cmd/hsup

--- a/cmd/hsup/main.go
+++ b/cmd/hsup/main.go
@@ -217,8 +217,6 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
-	log.Println("Args:", args, "LLArgs:", os.Args)
-
 	if len(args) == 0 {
 		flag.Usage()
 		os.Exit(1)

--- a/cmd/hsup/main.go
+++ b/cmd/hsup/main.go
@@ -41,6 +41,27 @@ func findDynoDriver(name string) (hsup.DynoDriver, error) {
 		return &hsup.DockerDynoDriver{}, nil
 	case "abspath":
 		return &hsup.AbsPathDynoDriver{}, nil
+	case "libcontainer":
+		newRoot := os.Getenv("HSUP_NEWROOT")
+		if newRoot == "" {
+			return nil, fmt.Errorf("HSUP_NEWROOT empty")
+		}
+
+		hostname := os.Getenv("HSUP_HOSTNAME")
+		if hostname == "" {
+			return nil, fmt.Errorf("HSUP_HOSTNAME empty")
+		}
+
+		user := os.Getenv("HSUP_USER")
+		if user == "" {
+			return nil, fmt.Errorf("HSUP_USER empty")
+		}
+
+		return &LibContainerDynoDriver{
+			NewRoot:  newRoot,
+			User:     user,
+			Hostname: hostname,
+		}, nil
 	default:
 		return nil, fmt.Errorf("could not locate driver. "+
 			"specified by the user: %v", name)
@@ -213,6 +234,20 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
+	log.Println("Args:", args, "LLArgs:", os.Args)
+	irData := os.Getenv("HSUP_INITRETURN_DATA")
+	if irData != "" {
+		// Used only with libcontainer Exec to set up
+		// namespaces and the like.  This *will* clear
+		// environment variables and Args from
+		// "CreateCommand", so be sure to be done processing
+		// or storing them before executing.
+		log.Println("running InitReturns")
+		if err := mustInitReturn(irData); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if len(args) == 0 {
 		flag.Usage()
 		os.Exit(1)
@@ -240,6 +275,16 @@ func main() {
 	dynoDriver, err := findDynoDriver(*dynoDriverName)
 	if err != nil {
 		log.Fatalln("could not initiate dyno driver:", err.Error())
+	}
+
+	// Inject information for delegation purposes to a
+	// LibContainerDynoDriver.
+	switch dd := dynoDriver.(type) {
+	case *LibContainerDynoDriver:
+		dd.envFill()
+		dd.Args = args
+		dd.AppName = *appName
+		dd.Concurrency = *concurrency
 	}
 
 	var poller hsup.Notifier

--- a/cmd/hsup/main.go
+++ b/cmd/hsup/main.go
@@ -243,7 +243,7 @@ func main() {
 		// "CreateCommand", so be sure to be done processing
 		// or storing them before executing.
 		log.Println("running InitReturns")
-		if err := mustInitReturn(irData); err != nil {
+		if err := mustInit(irData); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/hsup/main.go
+++ b/cmd/hsup/main.go
@@ -243,7 +243,7 @@ func main() {
 		// "CreateCommand", so be sure to be done processing
 		// or storing them before executing.
 		log.Println("running InitReturns")
-		if err := mustInit(irData); err != nil {
+		if err := hsup.MustInit(irData); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -280,8 +280,8 @@ func main() {
 	// Inject information for delegation purposes to a
 	// LibContainerDynoDriver.
 	switch dd := dynoDriver.(type) {
-	case *LibContainerDynoDriver:
-		dd.envFill()
+	case *hsup.LibContainerDynoDriver:
+		dd.EnvFill()
 		dd.Args = args
 		dd.AppName = *appName
 		dd.Concurrency = *concurrency

--- a/docker.go
+++ b/docker.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-type StackImage struct {
+type DockerStackImage struct {
 	stack string
 	image docker.APIImages
 }
@@ -42,8 +42,8 @@ func (d *Docker) Connect() (err error) {
 	return err
 }
 
-func (d *Docker) StackStat(stack string) (*StackImage, error) {
-	si := StackImage{
+func (d *Docker) StackStat(stack string) (*DockerStackImage, error) {
+	si := DockerStackImage{
 		stack: stack,
 	}
 
@@ -64,7 +64,7 @@ func (d *Docker) StackStat(stack string) (*StackImage, error) {
 	return nil, nil
 }
 
-func (d *Docker) BuildSlugImage(si *StackImage, release *Release) (
+func (d *Docker) BuildSlugImage(si *DockerStackImage, release *Release) (
 	string, error) {
 	// Exit early if the image is already around.
 	imageName := release.Name()

--- a/docker_dyno_driver.go
+++ b/docker_dyno_driver.go
@@ -7,8 +7,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
 	"path/filepath"
+
+	"github.com/fsouza/go-dockerclient"
 )
 
 type DockerDynoDriver struct {
@@ -20,6 +21,7 @@ func (dd *DockerDynoDriver) Build(release *Release) error {
 		return err
 	}
 
+	// TODO: map release.stack -> docker image name
 	stack := "heroku/cedar:14"
 	si, err := dd.d.StackStat(stack)
 	if err != nil {
@@ -43,6 +45,7 @@ func (dd *DockerDynoDriver) Start(ex *Executor) error {
 	as := AppSerializable{
 		Version: ex.Release.version,
 		Env:     ex.Release.config,
+		Stack:   ex.Release.stack,
 		Processes: []FormationSerializable{
 			{
 				FArgs:     ex.Args,

--- a/dyno_driver.go
+++ b/dyno_driver.go
@@ -50,3 +50,11 @@ func (r *Release) Where() SlugWhere {
 		return Local
 	}
 }
+
+func (r *Release) ConfigSlice() []string {
+	var c []string
+	for k, v := range r.config {
+		c = append(c, k+"="+v)
+	}
+	return c
+}

--- a/dyno_driver.go
+++ b/dyno_driver.go
@@ -21,6 +21,7 @@ type Release struct {
 	appName string
 	config  map[string]string
 	slugURL string
+	stack   string
 	version int
 
 	// docker dyno driver properties

--- a/executor.go
+++ b/executor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"fmt"
+
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -47,9 +48,10 @@ type Executor struct {
 	container *docker.Container
 
 	// libcontainer dyno driver properties
-	lcStatus    chan *ExitStatus
-	waitStartup chan struct{}
-	waitWait    chan struct{}
+	lcStatus      chan *ExitStatus
+	waitStartup   chan struct{}
+	waitWait      chan struct{}
+	containerUUID string
 
 	// FSM Fields
 	OneShot  bool

--- a/executor.go
+++ b/executor.go
@@ -39,12 +39,17 @@ type Executor struct {
 	Status      chan *ExitStatus
 	Complete    chan struct{}
 
-	// simple dyno driver properties
+	// simple, abspath, and libcontainer dyno driver properties
 	cmd     *exec.Cmd
 	waiting chan struct{}
 
 	// docker dyno driver properties
 	container *docker.Container
+
+	// libcontainer dyno driver properties
+	lcStatus    chan *ExitStatus
+	waitStartup chan struct{}
+	waitWait    chan struct{}
 
 	// FSM Fields
 	OneShot  bool

--- a/executor.go
+++ b/executor.go
@@ -83,7 +83,7 @@ func (e *Executor) Tick() (err error) {
 	start := func() error {
 		log.Printf("%v: starting\n", e.Name())
 		if err = e.DynoDriver.Start(e); err != nil {
-			log.Printf("%v: start fails: %v", e.Name(), err)
+			log.Printf("%v: start fails: %q", e.Name(), err.Error())
 			if e.OneShot {
 				go e.Trigger(Retire)
 			} else {

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -147,7 +147,7 @@ func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
 		code, err := namespaces.Exec(
 			container, os.Stdin, os.Stdout, os.Stderr,
 			console, dataPath, []string{},
-			initCtx.createCommand, initCtx.startCallback,
+			initCtx.createCommand, nil, initCtx.startCallback,
 		)
 		log.Println(code, err)
 		ex.lcStatus <- &ExitStatus{Code: code, Err: err}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package hsup
 
 import (

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -147,6 +147,27 @@ func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
 			initCtx.createCommand, nil, initCtx.startCallback,
 		)
 		log.Println(code, err)
+
+		// GC
+		// TODO: gc after sending back the exit status
+		// doing so right now terminates the program too early,
+		// before everything is removed
+		if err := syscall.Unmount(rootFSPath, 0); err != nil {
+			log.Printf("unmount error: %#+v", err)
+		}
+		if err := os.RemoveAll(appPath); err != nil {
+			log.Printf("remove all error: %#+v", err)
+		}
+		if err := os.RemoveAll(tmpPath); err != nil {
+			log.Printf("remove all error: %#+v", err)
+		}
+		if err := os.RemoveAll(varTmpPath); err != nil {
+			log.Printf("remove all error: %#+v", err)
+		}
+		if err := os.RemoveAll(dataPath); err != nil {
+			log.Printf("remove all error: %#+v", err)
+		}
+
 		ex.lcStatus <- &ExitStatus{Code: code, Err: err}
 		close(ex.lcStatus)
 	}()

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -313,7 +313,8 @@ func containerConfig(
 ) *libcontainer.Config {
 	return &libcontainer.Config{
 		MountConfig: &libcontainer.MountConfig{
-			PivotDir: "/tmp",
+			MountLabel: containerUUID,
+			PivotDir:   "/tmp",
 			Mounts: []*mount.Mount{
 				{
 					Type:        "bind",

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/gob"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/cgroups"
+	"github.com/docker/libcontainer/devices"
+	"github.com/docker/libcontainer/mount"
+	"github.com/docker/libcontainer/namespaces"
+)
+
+type LibContainerDynoDriver struct {
+	// LibContainer specific state.
+	NewRoot, Hostname, User string
+
+	// Filled to construct an abspath-driver invocation of hsup.
+	AppName     string
+	Concurrency int
+	Args, Env   []string
+}
+
+type lcCallbacks struct {
+	ex *Executor
+	dd *LibContainerDynoDriver
+}
+
+type initReturnArgs struct {
+	Container     *libcontainer.Config
+	UncleanRootfs string
+	ConsolePath   string
+}
+
+func (ira *initReturnArgs) Env() string {
+	buf := bytes.Buffer{}
+	b64enc := base64.NewEncoder(base64.StdEncoding, &buf)
+	enc := gob.NewEncoder(b64enc)
+	err := enc.Encode(&ira)
+	b64enc.Close()
+	if err != nil {
+		panic("could not encode initReturnArgs gob")
+	}
+
+	return "HSUP_INITRETURN_DATA=" + buf.String()
+}
+
+func mustInitReturn(irData string) (err error) {
+	d := gob.NewDecoder(base64.NewDecoder(base64.StdEncoding,
+		strings.NewReader(irData)))
+	ira := new(initReturnArgs)
+	if err = d.Decode(ira); err != nil {
+		panic("could not decode initReturnArgs")
+	}
+
+	return namespaces.InitReturn(ira.Container, ira.UncleanRootfs,
+		ira.ConsolePath, os.NewFile(3, "pipe"))
+}
+
+func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
+	dataPath, init string, pipe *os.File, args []string) *exec.Cmd {
+
+	ex := cb.ex
+	ex.cmd = exec.Command(os.Args[0],
+		append(cb.dd.Args, "-d", "abspath",
+			"-c", strconv.Itoa(cb.dd.Concurrency),
+			"-a", cb.dd.AppName)...)
+	log.Printf("%#+v")
+
+	ira := initReturnArgs{Container: container,
+		UncleanRootfs: cb.dd.NewRoot, ConsolePath: ""}
+
+	// Set up abspath driver environment.
+	ex.cmd.Env = append([]string{ira.Env()}, cb.dd.Env...)
+
+	if ex.cmd.SysProcAttr == nil {
+		ex.cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	ex.cmd.SysProcAttr.Cloneflags = uintptr(
+		namespaces.GetNamespaceFlags(
+			container.Namespaces))
+
+	ex.cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+	ex.cmd.ExtraFiles = []*os.File{pipe}
+
+	return ex.cmd
+}
+
+func (cb *lcCallbacks) StartCallback() {
+	log.Println("closing from StartCallback")
+	close(cb.ex.waitStartup)
+}
+
+func (dd *LibContainerDynoDriver) envFill() {
+	appendPresent := func(name string) {
+		val := os.Getenv(name)
+		if val != "" {
+			dd.Env = append(dd.Env, name+"="+val)
+		}
+	}
+	appendPresent("HEROKU_ACCESS_TOKEN")
+	appendPresent("CONTROL_DIR")
+}
+
+func (dd *LibContainerDynoDriver) Build(release *Release) error {
+	return nil
+}
+
+func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	ex.lcStatus = make(chan *ExitStatus)
+	ex.waitStartup = make(chan struct{})
+	ex.waitWait = make(chan struct{})
+	cb := lcCallbacks{ex: ex, dd: dd}
+
+	go func() {
+		code, err := namespaces.Exec(dd.lcconf(ex),
+			os.Stdin, os.Stdout, os.Stderr, "", pwd, []string{},
+			cb.CreateCommand, cb.StartCallback)
+		log.Println(code, err)
+		ex.lcStatus <- &ExitStatus{code: code, err: err}
+		close(ex.lcStatus)
+	}()
+
+	return nil
+}
+
+func (dd *LibContainerDynoDriver) Wait(ex *Executor) (s *ExitStatus) {
+	s = <-ex.lcStatus
+	close(ex.waitWait)
+	return s
+}
+
+func (dd *LibContainerDynoDriver) Stop(ex *Executor) error {
+	<-ex.waitStartup
+	// Some caller already successfully got a return from "Wait",
+	// which means the process exited: nothing to do.
+	if _, ok := <-ex.waitWait; !ok {
+		return nil
+	}
+
+	<-ex.lcStatus
+	p := ex.cmd.Process
+
+	// Begin graceful shutdown via SIGTERM.
+	p.Signal(syscall.SIGTERM)
+
+	for {
+		select {
+		case <-time.After(10 * time.Second):
+			log.Println("sigkill", p)
+			p.Signal(syscall.SIGKILL)
+		case <-ex.waiting:
+			log.Println("waited", p)
+			return nil
+		}
+		log.Println("spin", p)
+		time.Sleep(1)
+	}
+}
+
+func (dd *LibContainerDynoDriver) lcconf(ex *Executor) *libcontainer.Config {
+	lc := &libcontainer.Config{
+		MountConfig: &libcontainer.MountConfig{
+			Mounts: []*mount.Mount{
+				{
+					Type:        "tmpfs",
+					Destination: "/tmp",
+				},
+				{
+					Type:        "bind",
+					Source:      "/etc/resolv.conf",
+					Destination: "/etc/resolv.conf",
+				},
+			},
+			DeviceNodes: []*devices.Device{
+				{
+					Type:              99,
+					Path:              "/dev/null",
+					MajorNumber:       1,
+					MinorNumber:       3,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/zero",
+					MajorNumber:       1,
+					MinorNumber:       5,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/full",
+					MajorNumber:       1,
+					MinorNumber:       7,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/tty",
+					MajorNumber:       5,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/urandom",
+					MajorNumber:       1,
+					MinorNumber:       9,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/random",
+					MajorNumber:       1,
+					MinorNumber:       8,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+			},
+		},
+		RootFs:   dd.NewRoot,
+		Hostname: dd.Hostname,
+		User:     "0:0",
+		Env:      ex.release.ConfigSlice(),
+		Namespaces: map[string]bool{
+			"NEWIPC": true,
+			"NEWNET": true,
+			"NEWNS":  true,
+			"NEWPID": true,
+			"NEWUTS": true,
+		},
+		Capabilities: []string{
+			"CHOWN",
+			"DAC_OVERRIDE",
+			"FOWNER",
+			"MKNOD",
+			"NET_RAW",
+			"SETGID",
+			"SETUID",
+			"SETFCAP",
+			"SETPCAP",
+			"NET_BIND_SERVICE",
+			"SYS_CHROOT",
+			"KILL",
+		},
+		Networks: []*libcontainer.Network{
+			{
+				Address: "127.0.0.1/0",
+				Gateway: "localhost",
+				Mtu:     1500,
+				Type:    "loopback",
+			},
+			{
+				Address:    "172.17.0.101/16",
+				Bridge:     "docker0",
+				Gateway:    "172.17.42.1",
+				Mtu:        1500,
+				Type:       "veth",
+				VethPrefix: "veth",
+			},
+		},
+		Cgroups: &cgroups.Cgroup{
+			Name: dd.Hostname,
+			AllowedDevices: []*devices.Device{
+				{
+					Type:              99,
+					MajorNumber:       -1,
+					MinorNumber:       -1,
+					CgroupPermissions: "m",
+				},
+				{
+					Type:              98,
+					MajorNumber:       -1,
+					MinorNumber:       -1,
+					CgroupPermissions: "m",
+				},
+				{
+					Type:              99,
+					Path:              "/dev/console",
+					MajorNumber:       5,
+					MinorNumber:       1,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					Path:              "/dev/tty0",
+					MajorNumber:       4,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					Path:              "/dev/tty1",
+					MajorNumber:       4,
+					MinorNumber:       1,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					MajorNumber:       136,
+					MinorNumber:       -1,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					MajorNumber:       5,
+					MinorNumber:       2,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					MajorNumber:       10,
+					MinorNumber:       200,
+					CgroupPermissions: "rwm",
+				},
+				{
+					Type:              99,
+					Path:              "/dev/null",
+					MajorNumber:       1,
+					MinorNumber:       3,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/zero",
+					MajorNumber:       1,
+					MinorNumber:       5,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/full",
+					MajorNumber:       1,
+					MinorNumber:       7,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/tty",
+					MajorNumber:       5,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/urandom",
+					MajorNumber:       1,
+					MinorNumber:       9,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+				{
+					Type:              99,
+					Path:              "/dev/random",
+					MajorNumber:       1,
+					MinorNumber:       8,
+					CgroupPermissions: "rwm",
+					FileMode:          438,
+				},
+			},
+		},
+	}
+
+	return lc
+}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -60,27 +59,24 @@ func mustInit(irData string) (err error) {
 	if err = d.Decode(ira); err != nil {
 		panic("could not decode initReturnArgs")
 	}
-	log.Printf("init cmd: %#+v", os.Args)
+	log.Printf("init cmd: %#+v", os.Args[1:])
 
 	return namespaces.Init(ira.Container, ira.UncleanRootfs,
-		ira.ConsolePath, os.NewFile(3, "pipe"), os.Args)
+		ira.ConsolePath, os.NewFile(3, "pipe"), os.Args[1:])
 }
 
 func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
 	dataPath, init string, pipe *os.File, args []string) *exec.Cmd {
 
 	ex := cb.ex
-	ex.cmd = exec.Command(os.Args[0],
-		append(cb.dd.Args, "-d", "abspath",
-			"-c", strconv.Itoa(cb.dd.Concurrency),
-			"-a", cb.dd.AppName)...)
-	log.Printf("%#+v")
+	ex.cmd = exec.Command(os.Args[0], ex.args...)
 
 	ira := initReturnArgs{Container: container,
 		UncleanRootfs: cb.dd.NewRoot, ConsolePath: ""}
 
 	// Set up abspath driver environment.
 	ex.cmd.Env = append([]string{ira.Env()}, cb.dd.Env...)
+	log.Printf("%#+v", ex.cmd)
 
 	if ex.cmd.SysProcAttr == nil {
 		ex.cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -52,7 +52,7 @@ func (ira *initReturnArgs) Env() string {
 	return "HSUP_INITRETURN_DATA=" + buf.String()
 }
 
-func mustInit(irData string) (err error) {
+func MustInit(irData string) (err error) {
 	d := gob.NewDecoder(base64.NewDecoder(base64.StdEncoding,
 		strings.NewReader(irData)))
 	ira := new(initReturnArgs)
@@ -95,7 +95,7 @@ func (cb *lcCallbacks) StartCallback() {
 	close(cb.ex.waitStartup)
 }
 
-func (dd *LibContainerDynoDriver) envFill() {
+func (dd *LibContainerDynoDriver) EnvFill() {
 	appendPresent := func(name string) {
 		val := os.Getenv(name)
 		if val != "" {

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -200,7 +200,7 @@ func (ctx *containerInit) createCommand(container *libcontainer.Config, console,
 	}
 	cmd := exec.Command(ctx.hsupBinaryPath,
 		"-d", "libcontainer-init", "-a", ctx.ex.Release.appName,
-		"--oneshot", "--start-number", ctx.ex.ProcessID,
+		"--oneshot", "--start-number="+ctx.ex.ProcessID,
 		"start", ctx.ex.ProcessType,
 	)
 	cmd.Env = []string{
@@ -265,7 +265,7 @@ func (dd *LibContainerInitDriver) Start(ex *Executor) error {
 	}
 	args := []string{
 		"/tmp/hsup", "-d", "abspath", "-a", ex.Release.appName,
-		"--oneshot", "--start-number", ex.ProcessID,
+		"--oneshot", "--start-number=" + ex.ProcessID,
 		"start", ex.ProcessType,
 	}
 	container.Env = []string{

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -321,6 +321,7 @@ func containerConfig(
 				{
 					Type:        "bind",
 					Destination: "/app",
+					Writable:    true,
 					Source: filepath.Join(
 						dataPath,
 						"app",
@@ -329,6 +330,7 @@ func containerConfig(
 				{
 					Type:        "bind",
 					Destination: "/var/tmp",
+					Writable:    true,
 					Source: filepath.Join(
 						dataPath,
 						"var", "tmp",
@@ -336,6 +338,7 @@ func containerConfig(
 				},
 				{
 					Type:        "bind",
+					Writable:    false,
 					Destination: "/etc/resolv.conf",
 					Source:      "/etc/resolv.conf",
 				},

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -1,4 +1,4 @@
-package main
+package hsup
 
 import (
 	"bytes"
@@ -69,7 +69,7 @@ func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
 	dataPath, init string, pipe *os.File, args []string) *exec.Cmd {
 
 	ex := cb.ex
-	ex.cmd = exec.Command(os.Args[0], ex.args...)
+	ex.cmd = exec.Command(os.Args[0], ex.Args...)
 
 	ira := initReturnArgs{Container: container,
 		UncleanRootfs: cb.dd.NewRoot, ConsolePath: ""}
@@ -126,7 +126,7 @@ func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
 			os.Stdin, os.Stdout, os.Stderr, "", pwd, []string{},
 			cb.CreateCommand, cb.StartCallback)
 		log.Println(code, err)
-		ex.lcStatus <- &ExitStatus{code: code, err: err}
+		ex.lcStatus <- &ExitStatus{Code: code, Err: err}
 		close(ex.lcStatus)
 	}()
 
@@ -234,7 +234,7 @@ func (dd *LibContainerDynoDriver) lcconf(ex *Executor) *libcontainer.Config {
 		RootFs:   dd.NewRoot,
 		Hostname: dd.Hostname,
 		User:     "0:0",
-		Env:      ex.release.ConfigSlice(),
+		Env:      ex.Release.ConfigSlice(),
 		Namespaces: []libcontainer.Namespace{
 			{Type: "NEWIPC"},
 			{Type: "NEWNET"},

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -69,7 +70,11 @@ func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
 	dataPath, init string, pipe *os.File, args []string) *exec.Cmd {
 
 	ex := cb.ex
-	ex.cmd = exec.Command(ex.args[0], ex.args[1:]...)
+	ex.cmd = exec.Command(os.Args[0],
+		append(cb.dd.Args, "-d", "abspath",
+			"-c", strconv.Itoa(cb.dd.Concurrency),
+			"-a", cb.dd.AppName)...)
+	log.Printf("%#+v")
 
 	ira := initReturnArgs{Container: container,
 		UncleanRootfs: cb.dd.NewRoot, ConsolePath: ""}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -70,11 +69,7 @@ func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
 	dataPath, init string, pipe *os.File, args []string) *exec.Cmd {
 
 	ex := cb.ex
-	ex.cmd = exec.Command(os.Args[0],
-		append(cb.dd.Args, "-d", "abspath",
-			"-c", strconv.Itoa(cb.dd.Concurrency),
-			"-a", cb.dd.AppName)...)
-	log.Printf("%#+v")
+	ex.cmd = exec.Command(ex.args[0], ex.args[1:]...)
 
 	ira := initReturnArgs{Container: container,
 		UncleanRootfs: cb.dd.NewRoot, ConsolePath: ""}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -76,7 +76,6 @@ func (cb *lcCallbacks) CreateCommand(container *libcontainer.Config, console,
 
 	// Set up abspath driver environment.
 	ex.cmd.Env = append([]string{ira.Env()}, cb.dd.Env...)
-	log.Printf("%#+v", ex.cmd)
 
 	if ex.cmd.SysProcAttr == nil {
 		ex.cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/libcontainer_dyno_driver_stub.go
+++ b/libcontainer_dyno_driver_stub.go
@@ -1,0 +1,50 @@
+// +build !linux
+
+package hsup
+
+import "errors"
+
+var (
+	ErrDriverNotSupported = errors.New(
+		"the libcontainer driver is not supported on this platform",
+	)
+)
+
+type LibContainerDynoDriver struct{}
+
+func NewLibContainerDynoDriver(string) (*LibContainerDynoDriver, error) {
+	return nil, ErrDriverNotSupported
+}
+func (dd *LibContainerDynoDriver) Build(*Release) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerDynoDriver) Start(*Executor) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerDynoDriver) Stop(*Executor) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerDynoDriver) Wait(*Executor) *ExitStatus {
+	return nil
+}
+
+type LibContainerInitDriver struct{}
+
+func (dd *LibContainerInitDriver) Build(*Release) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerInitDriver) Start(*Executor) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerInitDriver) Stop(*Executor) error {
+	return ErrDriverNotSupported
+}
+
+func (dd *LibContainerInitDriver) Wait(*Executor) *ExitStatus {
+	return nil
+}

--- a/processes.go
+++ b/processes.go
@@ -1,10 +1,13 @@
 package hsup
 
 import (
-	"bitbucket.org/kardianos/osext"
 	"errors"
+	"io"
 	"log"
+	"os"
 	"runtime"
+
+	"bitbucket.org/kardianos/osext"
 )
 
 var ErrNoReleases = errors.New("No releases found")
@@ -39,4 +42,26 @@ func linuxAmd64Path() string {
 	}
 
 	return exe + "-linux-amd64"
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	r, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	w, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+	if err := os.Chmod(dst, mode); err != nil {
+		return err
+	}
+	return nil
 }

--- a/serialization.go
+++ b/serialization.go
@@ -11,6 +11,7 @@ type AppSerializable struct {
 	Version   int
 	Env       map[string]string
 	Slug      string
+	Stack     string
 	Processes []FormationSerializable
 }
 
@@ -58,6 +59,7 @@ func (as *AppSerializable) Procs(appName string, dd DynoDriver, oneShot bool) *P
 			appName: appName,
 			config:  as.Env,
 			slugURL: as.Slug,
+			stack:   as.Stack,
 			version: as.Version,
 		},
 		Forms:   make([]Formation, len(as.Processes)),

--- a/stack_image.go
+++ b/stack_image.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package hsup
 
 import (

--- a/stack_image.go
+++ b/stack_image.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -105,6 +106,7 @@ func (img *HerokuStackImage) mount() error {
 }
 
 func (img *HerokuStackImage) fetch() error {
+	log.Printf("Downloading stach image %q. This may take a while...", img.Name)
 	// TODO check md5
 	pr, pw := io.Pipe()
 	defer pr.Close()
@@ -147,5 +149,6 @@ func (img *HerokuStackImage) fetch() error {
 	if _, err := io.Copy(imageFile, r); err != nil {
 		return err
 	}
+	log.Println("Stack image download finished")
 	return <-dlResult
 }

--- a/stack_image.go
+++ b/stack_image.go
@@ -138,6 +138,7 @@ func (img *HerokuStackImage) fetch() error {
 		w := bufio.NewWriter(pw)
 		_, err := htcat.New(&client, u, 5).WriteTo(w)
 		dlResult <- err
+		w.Flush()
 	}()
 
 	r, err := gzip.NewReader(pr)

--- a/stack_image.go
+++ b/stack_image.go
@@ -1,0 +1,151 @@
+package hsup
+
+import (
+	"bufio"
+	"compress/gzip"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/htcat/htcat"
+	"gopkg.in/yaml.v2"
+)
+
+const HEROKU_STACKS_MANIFEST_URL = "https://s3.amazonaws.com/heroku_stacks_production/manifest.yml"
+
+type HerokuStackImage struct {
+	Name    string
+	Version string
+	URL     string `yaml:"url"`
+	Md5     string
+	Primary bool
+
+	basedir string
+}
+
+func HerokuStacksFromManifest(stacksDir string) ([]HerokuStackImage, error) {
+	// TODO: cache the manifest
+	resp, err := http.Get(HEROKU_STACKS_MANIFEST_URL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"invalid stacks manifest at %q",
+			HEROKU_STACKS_MANIFEST_URL,
+		)
+	}
+	manifest, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var stacks []HerokuStackImage
+	if err := yaml.Unmarshal(manifest, &stacks); err != nil {
+		return nil, err
+	}
+	for i, _ := range stacks {
+		stacks[i].basedir = stacksDir
+	}
+	return stacks, nil
+}
+
+func CurrentStackImagePath(stacksDir, name string) (string, error) {
+	// TODO: check if it is really mounted
+	// TODO: order by version numbers and pick the last
+	names, err := filepath.Glob(filepath.Join(stacksDir, name+"-*"))
+	if err != nil {
+		return "", err
+	}
+	last := len(names) - 1
+	for i := range names {
+		n := names[last-i]
+		if !strings.HasSuffix(n, ".img") {
+			return n, nil
+		}
+	}
+
+	return "", errors.New("no matching stack image found")
+}
+
+func (img *HerokuStackImage) Dir() string {
+	return filepath.Join(img.basedir, img.Name+"-"+img.Version)
+}
+
+func (img *HerokuStackImage) Filename() string {
+	return img.Dir() + ".img"
+}
+
+func (img *HerokuStackImage) mount() error {
+	var (
+		imgFile = img.Filename()
+		imgDir  = img.Dir()
+	)
+	if _, err := os.Stat(imgFile); err != nil {
+		if err := img.fetch(); err != nil {
+			return err
+		}
+	}
+	if contents, err := ioutil.ReadDir(imgDir); err != nil {
+		return err
+	} else if len(contents) != 0 {
+		return nil // already mounted
+	}
+	var flags uintptr = syscall.MS_NOATIME | syscall.MS_NODIRATIME |
+		syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_RDONLY
+	return syscall.Mount(imgFile, imgDir, "", flags, "")
+}
+
+func (img *HerokuStackImage) fetch() error {
+	// TODO check md5
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	defer pw.Close()
+
+	u, err := url.Parse(img.URL)
+	if err != nil {
+		return err
+	}
+
+	dlResult := make(chan error)
+	go func() {
+		client := *http.DefaultClient
+		if u.Scheme == "https" {
+			client.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{},
+			}
+		}
+		// buffer downloads in case decompression can't keep up
+		w := bufio.NewWriter(pw)
+		_, err := htcat.New(&client, u, 5).WriteTo(w)
+		dlResult <- err
+	}()
+
+	r, err := gzip.NewReader(pr)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	imageFile, err := os.Create(img.Filename())
+	if err != nil {
+		return err
+	}
+	defer imageFile.Close()
+	if err := imageFile.Chmod(0644); err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(imageFile, r); err != nil {
+		return err
+	}
+	return <-dlResult
+}

--- a/util/abspath-model
+++ b/util/abspath-model
@@ -9,8 +9,8 @@ mkdir -p $NEWROOT
 sudo umount $NEWROOT/tmp || true
 sudo umount $NEWROOT/etc/resolv.conf || true
 sudo umount $NEWROOT/etc/passwd || true
-sudo umount $NEWROOT/dev/urandom || true
-sudo umount $NEWROOT/dev/null || true
+sudo unlink $NEWROOT/dev/urandom || true
+sudo unlink $NEWROOT/dev/null || true
 
 if ! [ -e "$CEDAR_LOCAL_TARBALL" ]; then
     curl "https://heroku-dan-bucket.s3.amazonaws.com/$CEDAR_TARBALL" > \
@@ -25,9 +25,11 @@ host_bind() {
     sudo mount --bind "$1" "$NEWROOT$1"
 }
 
+copy_device() {
+    sudo cp -a "$1" "$NEWROOT$1"
+}
+
 host_bind /etc/resolv.conf
 host_bind /etc/passwd
-touch "$NEWROOT/dev/urandom"
-host_bind /dev/urandom
-touch "$NEWROOT/dev/null"
-host_bind /dev/null
+copy_device /dev/urandom
+copy_device /dev/null

--- a/util/abspath-model
+++ b/util/abspath-model
@@ -1,19 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 set -uex
+PREFIX=${PREFIX:-tmp}
 CEDAR_TARBALL=cedar-14.4.1.tgz
-CEDAR_LOCAL_TARBALL="tmp/$CEDAR_TARBALL"
-NEWROOT="tmp/root"
-mkdir -p tmp/root
+CEDAR_LOCAL_TARBALL="$PREFIX/$CEDAR_TARBALL"
+NEWROOT="$PREFIX/root"
+mkdir -p $NEWROOT
 
-sudo umount tmp/root/tmp || true
-sudo umount tmp/root/etc/resolv.conf || true
-sudo umount tmp/root/etc/passwd || true
-sudo umount tmp/root/dev/urandom || true
-sudo umount tmp/root/dev/null || true
+sudo umount $NEWROOT/tmp || true
+sudo umount $NEWROOT/etc/resolv.conf || true
+sudo umount $NEWROOT/etc/passwd || true
+sudo umount $NEWROOT/dev/urandom || true
+sudo umount $NEWROOT/dev/null || true
 
 if ! [ -e "$CEDAR_LOCAL_TARBALL" ]; then
     curl "https://heroku-dan-bucket.s3.amazonaws.com/$CEDAR_TARBALL" > \
-	"tmp/$CEDAR_TARBALL"
+	"$CEDAR_LOCAL_TARBALL"
 fi
 
 tar -C "$NEWROOT" -zxf "$CEDAR_LOCAL_TARBALL"


### PR DESCRIPTION
This seems to be working pretty well, as this [test](https://gist.github.com/fabiokung/c97259a298277e9a7a8f) shows.

The driver is split in two parts (`--driver libcontainer` and `--driver libcontainer-init`). The latter is not intended to be used directly, just a nice way I found to run `hsup` in a special mode (required by libcontainer) inside the container as PID=1.

Big TODOs:

* drop privileges: things still run as root inside the container. This will require UID allocation, injection of a `/etc/passwd` file inside the container, and calls to `setuid(2)` (with all the problems involved in doing it in Go).
* no networking: containers only have a loopback interface
* stack image management race conditions: if two `hsup` processes are started while stack images haven't been setup yet, they may race to fetch/mount them and affect each other.
* no support for local slugs yet. But this will be simple to add, the slug.tgz file just needs to be injected into the container, under `/tmp`.
* container data and volumes aren't garbage collected after the container terminates.

Overall, I think the driver is in a good (working) state to be merged.

/cc @fdr 