### PR TITLE
Always build inside a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tmp
 .idea
 *.iml
 hsup
+hsup-linux-amd64
 
 # Sourced from https://github.com/github/gitignore/blob/6f8aee0564363a55db374969c03dd35895801786/Go.gitignore
 #
@@ -29,3 +30,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,62 @@
+#!/usr/bin/env make -f
+
 SHELL = /bin/sh
 
 .SUFFIXES:
 
-osx:
+.PHONY: all clean deb docker-images
+
+# go build vars
+tempdir        := $(shell mktemp -d)
+gopkg          := $(tempdir)/pkg
+gosrc          := src/github.com/heroku/hsup
+
+# deb build vars
+packagename    := hsup
+version        := 0.0.1
+buildpath      := $(shell mktemp -d)
+controldir     := $(buildpath)/DEBIAN
+installpath    := $(buildpath)/usr/bin
+
+define DEB_CONTROL
+Package: $(packagename)
+Version: $(version)
+Architecture: amd64
+Maintainer: "Heroku Dogwood" <dogwood@heroku.com>
+Section: heroku
+Priority: optional
+Description: Heroku dyno supervisor
+endef
+export DEB_CONTROL
+
+
+all: hsup-linux-amd64
+
+clean:
+	rm -f $(packagename)*.deb
+	rm -f hsup
+	rm -f hsup-linux-amd64
+
+hsup:
 	godep go build -v -o hsup ./cmd/hsup
-	./build/on_osx.sh
+
+hsup-linux-amd64: hsup docker-images
+	mkdir -p -m 0755 $(gopkg)
+	docker run -it --rm -v $$GOPATH/$(gosrc):/go/$(gosrc) -v $(gopkg):/go/$(gosrc)/Godeps/_workspace/pkg golang:1.4 \
+	    /go/src/github.com/heroku/hsup/build/in_docker.sh
+	rm -rf $(tempdir)
+
+deb: all
+	mkdir -p -m 0755 $(controldir)
+	echo "$$DEB_CONTROL" > $(controldir)/control
+	mkdir -p $(installpath)
+	install hsup-linux-amd64 $(installpath)/$(packagename)
+	docker run -it --rm -v $(buildpath):/go/deb golang:1.4 \
+	    sh -c 'dpkg-deb --build deb . && install -m 0666 ./$(packagename)*.deb deb/'
+	cp $(buildpath)/$(packagename)*.deb .
+	rm -rf $(buildpath)
+
+# Assumes docker (or boot2docker on OSX) is installed, working and running
+docker-images:
+	docker pull golang:1.4
+

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ gosrc          := src/github.com/heroku/hsup
 # deb build vars
 packagename    := hsup
 version        := 0.0.1
-buildpath      := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'hsup.deb')
+buildpath      := $(shell pwd)/deb
 controldir     := $(buildpath)/DEBIAN
 installpath    := $(buildpath)/usr/bin
 

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ SHELL = /bin/sh
 .PHONY: all clean deb docker-images
 
 # go build vars
-tempdir        := $(shell mktemp -d)
+tempdir        := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'hsup.go')
 gopkg          := $(tempdir)/pkg
 gosrc          := src/github.com/heroku/hsup
 
 # deb build vars
 packagename    := hsup
 version        := 0.0.1
-buildpath      := $(shell mktemp -d)
+buildpath      := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'hsup.deb')
 controldir     := $(buildpath)/DEBIAN
 installpath    := $(buildpath)/usr/bin
 

--- a/build/in_docker.sh
+++ b/build/in_docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 cd /go/src/github.com/heroku/hsup
-go build -o godep-linux-amd64 github.com/tools/godep
-./godep-linux-amd64 go build -v -o hsup-linux-amd64 ./cmd/hsup
+go get github.com/tools/godep
+godep go install ./...
+cp /go/bin/hsup hsup-linux-amd64
+rm -rf Godeps/_workspace/pkg/*

--- a/build/on_osx.sh
+++ b/build/on_osx.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-# Assumes boot2docker is installed, working, running, and your current
-# env points at it correctly.
-docker pull golang:1.4
-
-docker run -it --rm -v $GOPATH:/go -w /usr/src/myapp golang:1.4 \
-    /go/src/github.com/heroku/hsup/build/in_docker.sh

--- a/build/readme.md
+++ b/build/readme.md
@@ -1,6 +1,6 @@
 ## building / using the docker driver on osx
 
 * Have boot2docker up and running, `docker ps` should be working locally.
-* run ./build/on_osx.sh
+* run `make`
 
 this will pull a linux based container with go 1.4 installed, and build an 'hsup-linux-amd64' binary that will get picked up when using the docker driver.

--- a/docker.go
+++ b/docker.go
@@ -154,7 +154,7 @@ WORKDIR /app
 	tr.Write([]byte(dockerContents))
 
 	if os.IsNotExist(err) {
-		log.Println("make a Linux binary: ./build/on_osx.sh")
+		log.Println("make a Linux binary: `make`")
 	}
 
 	tr.Close()


### PR DESCRIPTION
This normalizes builds on Linux and OSX, always using a docker container with its own `$GOPATH` to generate `hsup` binaries.

There is also a new `make` target to build a debian package, also using a docker container to make it work on OSX too.

/cc @sclasen 