### PR TITLE
Move hsup-linux-amd64 where linuxAmd64Path() expects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,9 @@ hsup:
 hsup-linux-amd64: hsup docker-images
 	mkdir -p -m 0755 $(gopkg)
 	docker run -it --rm -v $$GOPATH/$(gosrc):/go/$(gosrc) -v $(gopkg):/go/$(gosrc)/Godeps/_workspace/pkg golang:1.4 \
-	    /go/src/github.com/heroku/hsup/build/in_docker.sh
+	    /go/$(gosrc)/build/in_docker.sh
 	rm -rf $(tempdir)
+	mv $$GOPATH/$(gosrc)/hsup-linux-amd64 $$GOPATH/bin/
 
 deb: all
 	mkdir -p -m 0755 $(controldir)


### PR DESCRIPTION
Perhaps we want something a little fancier than this where it actually mounts `$GOPATH/bin/` in the container, but this was a quick fix I did to get `hsup` running on my Mac.