### PR TITLE
libcontainer driver: don't run user code as root

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -52,6 +52,7 @@ type Executor struct {
 	container *docker.Container
 
 	// libcontainer dyno driver properties
+	uid, gid      int
 	lcStatus      chan *ExitStatus
 	waitStartup   chan struct{}
 	waitWait      chan struct{}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -112,12 +112,12 @@ func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
 	if err := os.MkdirAll(dataPath, 0755); err != nil {
 		return err
 	}
-	writeablePaths := []string{
+	writablePaths := []string{
 		filepath.Join(dataPath, "app"),
 		filepath.Join(dataPath, "tmp"),
 		filepath.Join(dataPath, "var", "tmp"),
 	}
-	for _, path := range writeablePaths {
+	for _, path := range writablePaths {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			return err
 		}
@@ -197,7 +197,7 @@ func (dd *LibContainerDynoDriver) Start(ex *Executor) error {
 		if err := syscall.Unmount(rootFSPath, 0); err != nil {
 			log.Printf("unmount error: %#+v", err)
 		}
-		for _, path := range writeablePaths {
+		for _, path := range writablePaths {
 			if err := os.RemoveAll(path); err != nil {
 				log.Printf("remove all error: %#+v", err)
 			}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -314,6 +315,9 @@ func (dd *LibContainerInitDriver) Start(ex *Executor) error {
 	}
 	args := []string{"/tmp/hsup"}
 	container.Env = []string{"HSUP_CONTROL_GOB=" + hs.ToBase64Gob()}
+
+	runtime.LockOSThread() // required by namespaces.Init
+
 	// TODO: clean up /tmp/hsup and /tmp/slug.tgz after abspath reads them
 	return namespaces.Init(
 		&container, container.RootFs, "",

--- a/libcontainer_dyno_driver_test.go
+++ b/libcontainer_dyno_driver_test.go
@@ -1,0 +1,123 @@
+// +build linux
+
+package hsup
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestFindsAvailableUIDs(t *testing.T) {
+	workDir, err := ioutil.TempDir("", "hsup-libcontainer-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(workDir)
+	driver, err := NewLibContainerDynoDriver(workDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.minUID = 1
+	driver.maxUID = 3
+
+	// some uids are already allocated...
+	if err := createUIDFile(workDir, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := createUIDFile(workDir, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// uid=2 is the only available
+	uid, gid, err := driver.findFreeUIDGID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != 2 {
+		t.Fatalf("uid=2 was the only available and wasn't allocated. "+
+			"Found %d", uid)
+	}
+	if gid != 2 {
+		t.Fatalf("gid=2 was the only available and wasn't allocated. "+
+			"Found %d", gid)
+	}
+	if !checkUIDFile(workDir, 2) {
+		t.Fatal("a uid file to lock uid=2 wasn't created")
+	}
+}
+
+func TestOnlyUsesFreeUIDs(t *testing.T) {
+	workDir, err := ioutil.TempDir("", "hsup-libcontainer-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(workDir)
+	driver, err := NewLibContainerDynoDriver(workDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.minUID = 3000
+	driver.maxUID = 3004
+
+	// some uids are already allocated...
+	if err := createUIDFile(workDir, 3002); err != nil {
+		t.Fatal(err)
+	}
+	if err := createUIDFile(workDir, 3003); err != nil {
+		t.Fatal(err)
+	}
+
+	first, _, err := driver.findFreeUIDGID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checkUIDFile(workDir, first) {
+		t.Fatalf("a uid file to lock uid=%d wasn't created", first)
+	}
+
+	second, _, err := driver.findFreeUIDGID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checkUIDFile(workDir, second) {
+		t.Fatalf("a uid file to lock uid=%d wasn't created", second)
+	}
+	if first == second {
+		t.Fatalf("allocated uids should not be reused."+
+			" Failed %d != %d", first, second)
+	}
+
+	third, _, err := driver.findFreeUIDGID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checkUIDFile(workDir, third) {
+		t.Fatalf("a uid file to lock uid=%d wasn't created", third)
+	}
+	if first == third || second == third {
+		t.Fatalf("allocated uids should not be reused."+
+			" Failed %d != %d != %d", first, second, third)
+	}
+}
+
+func createUIDFile(workDir string, uid int) error {
+	f, err := os.Create(filepath.Join(workDir, "uids", strconv.Itoa(uid)))
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func checkUIDFile(workDir string, uid int) bool {
+	f, err := os.Open(filepath.Join(workDir, "uids"))
+	if err != nil {
+		return false
+	}
+	if err := f.Close(); err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Allocate unique UIDs for each container and run containers as unprivileged users.

/cc @fdr we may want to do something similar for the Docker driver. Without user namespaces, if processes somehow manage to escape their namespaces, they will be able to access other containers' resources/data, even without escalating to root, because they all run as the same user (uid=1000).