### PR TITLE
Automated functional testing infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 
 .SUFFIXES:
 
-.PHONY: all clean deb deb-local ftest ftest-libcontainer ftest-simple ftest-docker hsup-docker-container docker-images
+.PHONY: all clean deb deb-local ftest ftest-libcontainer ftest-simple ftest-docker hsup-docker-container docker-images boot2docker-init
 
 # go build vars
 tempdir        := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'hsup.go')
@@ -97,4 +97,9 @@ docker-images:
 
 hsup-docker-container:
 	docker build -t hsup .
+
+boot2docker-init:
+	boot2docker ssh "sudo sh -c \
+	    'mkdir -p /mnt/sda1/var/lib/hsup && \
+	    ln -sf /mnt/sda1/var/lib/hsup /var/lib/hsup'"
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ ls "$HSUP_CONTROL_DIR"
 
 ## Running the libcontainer driver within Docker
 
+If you are using boot2docker, do the necessary preparation to expand the
+available disk space for hsup data:
+
+```sh-session
+$ make boot2docker-init
+```
+
 Containers (hsup/libcontainer) inside containers (docker). Inception!
 
 ```sh-session
@@ -110,6 +117,12 @@ $ docker run --privileged -v /tmp/supctl:/etc/hsup -v /tmp/stacks:/var/lib/hsup/
 ```
 
 ## Automated functional tests
+
+If you are using boot2docker (check the section above for details):
+
+```sh-session
+$ make boot2docker-init
+```
 
 To run several functional tests against a `hsup` binary:
 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,39 @@ json control files are required:
 $ docker run --privileged -v /tmp/supctl:/etc/hsup -v /tmp/stacks:/var/lib/hsup/stacks -it hsup
 (/tmp/supctl/new or /tmp/supctl/loaded will be used as the control file)
 ```
+
+## Automated functional tests
+
+To run several functional tests against a `hsup` binary:
+
+```sh-session
+$ godep go test ./ftest -driver docker -hsup <path-to-compiled-hsup-binary>
+```
+
+Different drivers (`libcontainer`, `simple`) can be specified with the `driver`
+flag, but note that the libcontainer driver requires `root` privileges:
+
+```sh-session
+$ sudo -E $(which godep) go test ./ftest -driver libcontainer -hsup <path-to-hsup-binary>
+```
+
+All tests can also be executed inside docker containers (see the
+hsup-inside-docker section above) with:
+
+```sh-session
+$ make ftest
+runs libcontainer driver tests by default
+
+$ make ftest driver=docker
+specify a custom driver
+
+$ make ftest-libcontainer
+libcontainer driver tests...
+
+$ make ftest-docker
+docker driver tests...
+
+$ make ftest-simple
+simple driver tests...
+```
+

--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ Supervises processes that are configured in a Heroku-esque way.
 configuration, and execution information.  `hsup` can also watch a
 local directory that injects similar information.
 
-The execution is performed with a chosen "dyno driver".  The default
-dyno driver, `simple`, downloads and refreshes the environment only.
-There is also a `docker` dyno driver that both obtains the environment
-and executable code and runs it interposed on the `heroku/cedar:14`
-image.
+The execution is performed with a chosen "dyno driver":
+
+* The default dyno driver, `simple`, downloads and refreshes the environment
+  only.
+* The `docker` dyno driver both obtains the environment and executable code and
+  runs it interposed on the `heroku/cedar:14` image.
+* The `libcontainer` driver is similar to the Docker driver, but runs containers
+  in foreground, on top of Heroku official (read only) stack images. It needs to
+  be executed as root (e.g.: `sudo`) and only works on Linux machines. See notes
+  about running it in Docker (below) for nested (hsup-in-docker) support and
+  execution on any host with Docker installed (e.g.: boot2docker).
 
 Usage:
 

--- a/WIP.md
+++ b/WIP.md
@@ -11,7 +11,7 @@ paths, e.g. chroot environments and containers.
 
 Example:
 
-```
+```sh-session
 # Sets up a minimal "Cedar-14" chroot in 'tmp/root'
 $ ./util/abspath-model
 
@@ -25,21 +25,3 @@ $ godep go build &&
     "HEROKU_ACCESS_TOKEN=$HEROKU_ACCESS_TOKEN" \
     /hsup run printenv -d abspath -a "$HSUP_APP"
 ```
-
-## libcontainer driver
-
-It works (with a few caveats listed below), but requires `root` to be used:
-
-```
-$ godep go install ./... && sudo env HSUP_CONTROL_DIR=/tmp/hspctl \
-  hsup run -d libcontainer '/bin/bash'
-```
-
-Caveats:
-
-* it must be build with `godep`
-* no support for local slugs
-* no privilege dropping, containers still run as root
-* no networking
-* container data is not being garbage collected yet
-* libcontainerDriver.Stop() (probably) doesn't currently work

--- a/WIP.md
+++ b/WIP.md
@@ -4,6 +4,22 @@
 overwhelming the README for casual reading, is for notes in testing
 and developing new features.
 
+## docker image caching
+
+Docker images can be cached and re-used for each (app, release) tuple. To enable
+caching, use the `DOCKER_IMAGE_CACHE` env var:
+
+```sh-session
+$ export DOCKER_IMAGE_CACHE=1 HSUP_CONTROL_DIR=/tmp/supctl
+$ hsup start -a myapp web=1
+```
+
+This avois slugs being downloaded all the time, but beware that the cache needs
+to be invalidated manually, and an hsup binary will be baked into the cached
+image the first time it's built. If you need to update hsup inside the image,
+invalidade the cache manually by deleting the image in docker directly, or
+running hsup again with the cache disabled.
+
 ## abspath driver
 
 `hsup` is learning to deal with environments set up with absolute

--- a/docker.go
+++ b/docker.go
@@ -125,7 +125,7 @@ func (d *Docker) BuildSlugImage(si *DockerStackImage, release *Release) (
 
 	// Generate Dockerfile and place in archive.
 	genv := "HSUP_CONTROL_GOB=" + hs.ToBase64Gob()
-	args := []string{"setuidgid", "dyno", "env", genv, "/tmp/hsup"}
+	args := []string{"setuidgid", "dyno", "env", genv, "/hsup"}
 	argText, err := json.Marshal(args)
 	if err != nil {
 		panic(fmt.Sprintln("could not marshal argv:", args))
@@ -139,11 +139,10 @@ func (d *Docker) BuildSlugImage(si *DockerStackImage, release *Release) (
 	}
 
 	dockerContents := fmt.Sprintf(`FROM %s
-COPY hsup /tmp/hsup
-RUN groupadd -r dyno && useradd -r -g dyno dyno && mkdir /app && chown dyno:dyno /app && chmod a+x /tmp/hsup
+COPY hsup /hsup
+RUN groupadd -r dyno && useradd -r -g dyno dyno && mkdir /app && chown dyno:dyno /app && chmod a+x /hsup
 %s
 RUN %s
-RUN rm /tmp/hsup
 WORKDIR /app
 `, si.image.ID, localSlugText, argText)
 

--- a/docker_dyno_driver.go
+++ b/docker_dyno_driver.go
@@ -7,8 +7,6 @@ import (
 	"syscall"
 	"time"
 
-	"path/filepath"
-
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -71,7 +69,6 @@ func (dd *DockerDynoDriver) Start(ex *Executor) error {
 	// unique
 	name := fmt.Sprintf("%v.%v", ex.Name(), time.Now().Unix())
 	vols := make(map[string]struct{})
-	vols["/hsup"] = struct{}{}
 	for _, inside := range ex.Binds {
 		vols[inside] = struct{}{}
 	}
@@ -91,13 +88,8 @@ func (dd *DockerDynoDriver) Start(ex *Executor) error {
 	}
 	ex.container = container
 
-	where, err := filepath.Abs(linuxAmd64Path())
-	if err != nil {
-		return err
-	}
-
 	err = dd.d.c.StartContainer(ex.container.ID, &docker.HostConfig{
-		Binds:           append([]string{where + ":/hsup"}, ex.bindPairs()...),
+		Binds:           ex.bindPairs(),
 		PublishAllPorts: true,
 	})
 	if err != nil {

--- a/ftest/ftest.go
+++ b/ftest/ftest.go
@@ -21,9 +21,6 @@ func init() {
 	flag.StringVar(&binary, "hsup", "", "dyno execution driver")
 	flag.StringVar(&driver, "driver", "simple", "dyno execution driver")
 	flag.Parse()
-	if binary == "" {
-		panic("Missing the hsup binary location (-hsup flag).")
-	}
 }
 
 type output struct {

--- a/ftest/ftest.go
+++ b/ftest/ftest.go
@@ -1,0 +1,65 @@
+package ftest
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/heroku/hsup"
+)
+
+var (
+	binary string
+	driver string
+)
+
+func init() {
+	flag.StringVar(&binary, "hsup", "", "dyno execution driver")
+	flag.StringVar(&driver, "driver", "simple", "dyno execution driver")
+	flag.Parse()
+	if binary == "" {
+		panic("Missing the hsup binary location (-hsup flag).")
+	}
+}
+
+type output struct {
+	out bytes.Buffer
+	err bytes.Buffer
+}
+
+func run(app hsup.AppSerializable, args ...string) (*output, error) {
+	controlDir, err := ioutil.TempDir("", "hsup-test-control")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(controlDir)
+
+	controlFile, err := os.Create(filepath.Join(controlDir, "new"))
+	if err != nil {
+		return nil, err
+	}
+	defer controlFile.Close()
+	if err := json.NewEncoder(controlFile).Encode(&app); err != nil {
+		return nil, err
+	}
+	if err := controlFile.Sync(); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(binary, append(
+		[]string{"-d", driver, "run"},
+		args...,
+	)...)
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HSUP_CONTROL_DIR=" + controlDir,
+	}
+	var output output
+	cmd.Stdout = &output.out
+	cmd.Stderr = &output.err
+	return &output, cmd.Run()
+}

--- a/ftest/run_test.go
+++ b/ftest/run_test.go
@@ -1,0 +1,62 @@
+package ftest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/heroku/hsup"
+)
+
+func TestEnv(t *testing.T) {
+	if driver == "simple" {
+		t.Log("Skipping ENV tests on the simple driver")
+		return
+	}
+
+	app := hsup.AppSerializable{
+		Version:   1,
+		Name:      "test-app-123",
+		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
+		Stack:     "cedar-14",
+		Processes: make([]hsup.FormationSerializable, 0),
+	}
+	output, err := run(app, "env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.out.String(), "DYNO=run.1") {
+		t.Fatal("Expected ENV entry not found: DYNO")
+	}
+	if !strings.Contains(
+		output.out.String(),
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	) {
+		t.Fatal("Expected ENV entry not found: DYNO")
+	}
+	if !strings.Contains(output.out.String(), "PWD=/app") {
+		t.Fatal("Expected ENV entry not found: PWD")
+	}
+	if !strings.Contains(output.out.String(), "HOME=/app") {
+		t.Fatal("Expected ENV entry not found: HOME")
+	}
+}
+
+func TestSimpleBashExprWithVar(t *testing.T) {
+	app := hsup.AppSerializable{
+		Version: 1,
+		Name:    "test-app-123",
+		Env: map[string]string{
+			"TESTENTRY": "vAlId",
+		},
+		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
+		Stack:     "cedar-14",
+		Processes: make([]hsup.FormationSerializable, 0),
+	}
+	output, err := run(app, "echo $TESTENTRY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(output.out.String()) != "vAlId" {
+		t.Fatal("Expected ENV var not found: $TESTENTRY")
+	}
+}

--- a/ftest/run_test.go
+++ b/ftest/run_test.go
@@ -31,6 +31,8 @@ func TestEnv(t *testing.T) {
 		Processes: make([]hsup.FormationSerializable, 0),
 	}
 	output, err := run(app, "env")
+	t.Log(output.out.String())
+	t.Log(output.err.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,6 +65,8 @@ func TestSimpleBashExprWithVar(t *testing.T) {
 		Processes: make([]hsup.FormationSerializable, 0),
 	}
 	output, err := run(app, "echo $TESTENTRY")
+	t.Log(output.out.String())
+	t.Log(output.err.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ftest/run_test.go
+++ b/ftest/run_test.go
@@ -1,11 +1,21 @@
 package ftest
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/heroku/hsup"
 )
+
+func TestMain(m *testing.M) {
+	if binary == "" {
+		fmt.Fprintln(os.Stderr, "no hsup binary specified, skipping functional tests")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestEnv(t *testing.T) {
 	if driver == "simple" {


### PR DESCRIPTION
Add infrastructure for functional tests.

To simplify development on non-Linux machines, tests for all drivers can be executed inside Docker containers with `hsup-in-docker`. There are make targets for each driver.