### PR TITLE
libcontainer driver: make dyno IPs configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ tmp
 *.iml
 hsup
 hsup-linux-amd64
+hsctl
+supctl
 
 # Sourced from https://github.com/github/gitignore/blob/6f8aee0564363a55db374969c03dd35895801786/Go.gitignore
 #

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ ftest: hsup-docker-container
 	    ln -s /app /var/cache/buildpack/go1.4.1/go/src/github.com/heroku/hsup && \
 	    env PATH=/var/lib/buildpack/linux-amd64/bin/:/var/cache/buildpack/go1.4.1/go/bin:$$PATH \
 	    GOROOT=/var/cache/buildpack/go1.4.1/go \
-	    godep go test ./ftest -driver $(driver) -hsup /app/bin/hsup'
+	    godep go test $(GO_TEST_FLAGS) ./ftest -driver $(driver) -hsup /app/bin/hsup'
 
 ftest-libcontainer: driver = libcontainer
 ftest-libcontainer: ftest

--- a/README.md
+++ b/README.md
@@ -177,4 +177,10 @@ Some drivers accept custom configuration via ENV.
 
 * `LIBCONTAINER_DYNO_SUBNET`: a CIDR block to allocate dyno subnets (of size
   /30) from. It is `172.16.0.0/12` (RFC1918) by default when not set.
+* `LIBCONTAINER_DYNO_UID_MIN` and `LIBCONTAINER_DYNO_UID_MAX`: Linux UIDs to use
+  for each dyno. It also defines the maximum number of allowed dynos, as each
+  dyno gets a unique UID per box. To avoid reusing subnets (IPs), make sure that
+  `(maxUID - minUID) <= /30 subnets that LIBCONTAINER_DYNO_SUBNET can provide`.
+  `172.17.0.0/16` can provide `2 ** (30-16)` = **16384** subnets of size /30. In
+  this case, to avoid subnets being reused, make sure that `(maxUID - minUID) <= 16384`.
 

--- a/README.md
+++ b/README.md
@@ -163,3 +163,18 @@ $ make ftest-simple
 simple driver tests...
 ```
 
+## Driver specific configuration
+
+Some drivers accept custom configuration via ENV.
+
+### Docker
+
+* `DOCKER_HOST`
+* `DOCKER_CERT_PATH`
+* `DOCKER_IMAGE_CACHE`: when set, docker images are only built once per release.
+
+### Libcontainer
+
+* `LIBCONTAINER_DYNO_SUBNET`: a CIDR block to allocate dyno subnets (of size
+  /30) from. It is `172.16.0.0/12` (RFC1918) by default when not set.
+

--- a/allocator.go
+++ b/allocator.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"math/big"
 	"math/rand"
@@ -183,7 +182,6 @@ func subnetsToSkip(baseIP net.IP, subnetSize int) (uint32, error) {
 	if err := binary.Read(b, binary.BigEndian, &baseIPAsInt); err != nil {
 		return 0, err
 	}
-	log.Printf(">>> BASE: %d", baseIPAsInt)
 	// cut the first subnetSize bits
 	toSkip := baseIPAsInt << uint32(subnetSize)
 	toSkip >>= uint32(subnetSize)

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -18,25 +18,19 @@ func TestFirstAvailableInDefaultPrivateNet(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(workDir)
-	allocator, err := NewAllocator(
-		workDir,
-		DefaultPrivateSubnet,
-		DefaultBasePrivateIP,
-	)
+	allocator, err := NewAllocator(workDir, DefaultPrivateSubnet)
 	if err != nil {
 		t.Fatal(err)
 	}
 	minUID := 3000
-	net, err := allocator.privateNetForUID(minUID)
+	first, err := allocator.privateNetForUID(minUID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := DefaultBasePrivateIP
-	if !bytes.Equal(net.IP, expected.IP) ||
-		!bytes.Equal(net.Mask, expected.Mask) {
-		t.Fatalf("the first available private network is not"+
-			" 172.16.0.28/30. Got %#+v, Want %#+v", net, expected)
-	}
+	checkIPNet(t, first, &net.IPNet{
+		IP:   net.IPv4(172, 16, 0, 28).To4(),
+		Mask: net.CIDRMask(30, 32),
+	})
 }
 
 // RFC1918: 172.16/12 private address space is the default
@@ -46,11 +40,7 @@ func TestAllocatesNetworksInRFC1918SpaceByDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(workDir)
-	allocator, err := NewAllocator(
-		workDir,
-		DefaultPrivateSubnet,
-		DefaultBasePrivateIP,
-	)
+	allocator, err := NewAllocator(workDir, DefaultPrivateSubnet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,11 +93,7 @@ func TestAllocatesNetworksFromConfigurableBlock(t *testing.T) {
 		IP:   net.IPv4(127, 128, 0, 0).To4(),
 		Mask: net.CIDRMask(16, 32),
 	}
-	startAt := net.IPNet{
-		IP:   net.IPv4(127, 128, 0, 0).To4(),
-		Mask: net.CIDRMask(30, 32),
-	}
-	allocator, err := NewAllocator(workDir, block, startAt)
+	allocator, err := NewAllocator(workDir, block)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +104,10 @@ func TestAllocatesNetworksFromConfigurableBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkIPNet(t, first, &startAt)
+	checkIPNet(t, first, &net.IPNet{
+		IP:   net.IPv4(127, 128, 0, 0).To4(),
+		Mask: net.CIDRMask(30, 32),
+	})
 
 	second, err := allocator.privateNetForUID(minUID + 1)
 	if err != nil {
@@ -148,11 +137,7 @@ func TestFindsAvailableUIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(workDir)
-	allocator, err := NewAllocator(
-		workDir,
-		DefaultPrivateSubnet,
-		DefaultBasePrivateIP,
-	)
+	allocator, err := NewAllocator(workDir, DefaultPrivateSubnet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,11 +172,7 @@ func TestOnlyUsesFreeUIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(workDir)
-	allocator, err := NewAllocator(
-		workDir,
-		DefaultPrivateSubnet,
-		DefaultBasePrivateIP,
-	)
+	allocator, err := NewAllocator(workDir, DefaultPrivateSubnet)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ftest/ftest.go
+++ b/ftest/ftest.go
@@ -28,7 +28,7 @@ type output struct {
 	err bytes.Buffer
 }
 
-func run(app hsup.AppSerializable, args ...string) (*output, error) {
+func run(app hsup.AppSerializable, hsupEnv []string, args ...string) (*output, error) {
 	controlDir, err := ioutil.TempDir("", "hsup-test-control")
 	if err != nil {
 		return nil, err
@@ -51,10 +51,10 @@ func run(app hsup.AppSerializable, args ...string) (*output, error) {
 		[]string{"-d", driver, "run"},
 		args...,
 	)...)
-	cmd.Env = []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HSUP_CONTROL_DIR=" + controlDir,
-	}
+	cmd.Env = append(hsupEnv,
+		"PATH="+os.Getenv("PATH"),
+		"HSUP_CONTROL_DIR="+controlDir,
+	)
 	var output output
 	cmd.Stdout = &output.out
 	cmd.Stderr = &output.err

--- a/ftest/libcontainer_test.go
+++ b/ftest/libcontainer_test.go
@@ -1,0 +1,50 @@
+package ftest
+
+// Libcontainer driver functional tests
+
+import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestConfigurableLibcontainerDynoSubnet(t *testing.T) {
+	onlyWithLibcontainer(t)
+
+	output, err := run(
+		AppMinimal, []string{
+			"LIBCONTAINER_DYNO_SUBNET=192.168.200.0/30",
+		},
+		`ip -o addr show eth0 | grep -w inet | awk '{print $4}'`,
+	)
+	debug(t, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(output.out.String()) != "192.168.200.2/30" {
+		t.Fatal("Expected the assigned IP to be: 192.168.200.2/30")
+	}
+}
+
+func TestConfigurableUIDRange(t *testing.T) {
+	onlyWithLibcontainer(t)
+
+	// [3000,10000) range
+	uid := strconv.Itoa(rand.Intn(7000) + 3000)
+	output, err := run(
+		AppMinimal, []string{
+			// Force a single UID
+			"LIBCONTAINER_DYNO_UID_MIN=" + uid,
+			"LIBCONTAINER_DYNO_UID_MAX=" + uid,
+		},
+		`id -u`,
+	)
+	debug(t, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(output.out.String()) != uid {
+		t.Fatal("Expected the assigned UID to be: ", uid)
+	}
+}

--- a/ftest/run_test.go
+++ b/ftest/run_test.go
@@ -1,21 +1,9 @@
 package ftest
 
 import (
-	"fmt"
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/heroku/hsup"
 )
-
-func TestMain(m *testing.M) {
-	if binary == "" {
-		fmt.Fprintln(os.Stderr, "no hsup binary specified, skipping functional tests")
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
 
 func TestEnv(t *testing.T) {
 	if driver == "simple" {
@@ -23,16 +11,8 @@ func TestEnv(t *testing.T) {
 		return
 	}
 
-	app := hsup.AppSerializable{
-		Version:   1,
-		Name:      "test-app-123",
-		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
-		Stack:     "cedar-14",
-		Processes: make([]hsup.FormationSerializable, 0),
-	}
-	output, err := run(app, []string{}, "env")
-	t.Log(output.out.String())
-	t.Log(output.err.String())
+	output, err := run(AppMinimal, []string{}, "env")
+	debug(t, output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,55 +34,12 @@ func TestEnv(t *testing.T) {
 }
 
 func TestSimpleBashExprWithVar(t *testing.T) {
-	app := hsup.AppSerializable{
-		Version: 1,
-		Name:    "test-app-123",
-		Env: map[string]string{
-			"TESTENTRY": "vAlId",
-		},
-		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
-		Stack:     "cedar-14",
-		Processes: make([]hsup.FormationSerializable, 0),
-	}
-	output, err := run(app, []string{}, "echo $TESTENTRY")
-	t.Log(output.out.String())
-	t.Log(output.err.String())
+	output, err := run(AppWithEnv, []string{}, "echo $TESTENTRY")
+	debug(t, output)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if strings.TrimSpace(output.out.String()) != "vAlId" {
 		t.Fatal("Expected ENV var not found: $TESTENTRY")
-	}
-}
-
-func TestConfigurableLibcontainerDynoSubnet(t *testing.T) {
-	if driver != "libcontainer" {
-		t.Log("Skipping libcontainer specific test on driver ", driver)
-		return
-	}
-
-	app := hsup.AppSerializable{
-		Version: 1,
-		Name:    "test-app-123",
-		Env: map[string]string{
-			"TESTENTRY": "vAlId",
-		},
-		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
-		Stack:     "cedar-14",
-		Processes: make([]hsup.FormationSerializable, 0),
-	}
-	output, err := run(
-		app, []string{
-			"LIBCONTAINER_DYNO_SUBNET=192.168.200.0/30",
-		},
-		`ip -o addr show eth0 | grep -w inet | awk '{print $4}'`,
-	)
-	t.Log(output.out.String())
-	t.Log(output.err.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(output.out.String()) != "192.168.200.2/30" {
-		t.Fatal("Expected the assigned IP to be: 192.168.200.2/30")
 	}
 }

--- a/ftest/shared_test.go
+++ b/ftest/shared_test.go
@@ -1,0 +1,51 @@
+package ftest
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/heroku/hsup"
+)
+
+func TestMain(m *testing.M) {
+	if binary == "" {
+		fmt.Fprintln(os.Stderr, "no hsup binary specified, skipping functional tests")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// Fixtures
+var (
+	AppMinimal = hsup.AppSerializable{
+		Version:   1,
+		Name:      "test-app-123",
+		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
+		Stack:     "cedar-14",
+		Processes: make([]hsup.FormationSerializable, 0),
+	}
+
+	AppWithEnv = hsup.AppSerializable{
+		Version: 1,
+		Name:    "test-app-123",
+		Env: map[string]string{
+			"TESTENTRY": "vAlId",
+		},
+		Slug:      "https://s3.amazonaws.com/sclasen-herokuslugs/slug.tgz",
+		Stack:     "cedar-14",
+		Processes: make([]hsup.FormationSerializable, 0),
+	}
+)
+
+// Helpers
+func onlyWithLibcontainer(t *testing.T) {
+	if driver != "libcontainer" {
+		t.Skip("Skipping libcontainer specific test on driver ", driver)
+	}
+}
+
+func debug(t *testing.T, output *output) {
+	t.Log(output.out.String())
+	t.Log(output.err.String())
+}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -45,7 +45,11 @@ func NewLibContainerDynoDriver(workDir string) (*LibContainerDynoDriver, error) 
 	if err := os.MkdirAll(containersDir, 0755); err != nil {
 		return nil, err
 	}
-	allocator, err := NewAllocator(workDir)
+	allocator, err := NewAllocator(
+		workDir,
+		DefaultPrivateSubnet,
+		DefaultBasePrivateIP,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -45,11 +45,7 @@ func NewLibContainerDynoDriver(workDir string) (*LibContainerDynoDriver, error) 
 	if err := os.MkdirAll(containersDir, 0755); err != nil {
 		return nil, err
 	}
-	allocator, err := NewAllocator(
-		workDir,
-		DefaultPrivateSubnet,
-		DefaultBasePrivateIP,
-	)
+	allocator, err := NewAllocator(workDir, DefaultPrivateSubnet)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer_network.go
+++ b/libcontainer_network.go
@@ -83,9 +83,10 @@ func (r *Routed) enablePacketForwarding() error {
 }
 
 func (r *Routed) natOutboundTraffic() error {
+	// TODO the private network needs to be configurable
 	masquerade := []string{
 		"POSTROUTING", "-t", "nat",
-		"-s", privateSubnet.String(),
+		"-s", DefaultPrivateSubnet.String(),
 		"-j", "MASQUERADE",
 	}
 	if !iptables.Exists(masquerade...) {

--- a/libcontainer_network.go
+++ b/libcontainer_network.go
@@ -22,6 +22,7 @@ var (
 // offering containers only layer 3 connectivity to the outside world.
 type Routed struct {
 	network.Veth
+	privateSubnet net.IPNet
 }
 
 // Create sets up a veth pair, setting the config.Gateway address on the master
@@ -86,10 +87,12 @@ func (r *Routed) natOutboundTraffic() error {
 	// TODO the private network needs to be configurable
 	masquerade := []string{
 		"POSTROUTING", "-t", "nat",
-		"-s", DefaultPrivateSubnet.String(),
+		"-s", r.privateSubnet.String(),
 		"-j", "MASQUERADE",
 	}
-	if !iptables.Exists(masquerade...) {
+	if _, err := iptables.Raw(
+		append([]string{"-C"}, masquerade...)...,
+	); err != nil {
 		incl := append([]string{"-I"}, masquerade...)
 		if output, err := iptables.Raw(incl...); err != nil {
 			return err


### PR DESCRIPTION
IPs will be allocated from a CIDR block specified by the `$LIBCONTAINER_DYNO_SUBNET` env var, or `172.16/12` by default if not specified.

This also replaces the legacy (old) static IP configuration for dynos. The same can be achieved with a very small CIDR block that only provides a single `/30` dyno subnet:

```
HSUP_CONTROL_DIR=... LIBCONTAINER_DYNO_SUBNET=192.168.100.0/30 hsup -d libcontainer ...
# will always assign the same 192.168.100.2 IP to all dynos
```

The `uid` range assigned to dynos (with the libcontainer driver) is now also configurable with `LIBCONTAINER_DYNO_UID_MIN` and `LIBCONTAINER_DYNO_UID_MAX`.
