### PR TITLE
Use "$*" to run command without word splitting

### DIFF
--- a/abspath_dyno_driver.go
+++ b/abspath_dyno_driver.go
@@ -36,8 +36,7 @@ if [ -d /app/.profile.d ]; then
 fi
 
 rm $0
-cmd="$@" # trick to disable word splitting
-exec bash -c "$cmd"
+exec bash -c "$*"
 `
 
 type profileRunner struct {


### PR DESCRIPTION
The `$*` variable is equivalent to all incoming arguments with spaces between them: to quote it is to interpret all of them as one string.