### PR TITLE
Use `git describe` to calculate a nice version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ go: 1.4.2
 before_install:
 - export PATH=$HOME/gopath/bin:$PATH
 - go get github.com/tools/godep
-script:
-- godep go test ./...
-- make deb-local
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then b="build-$TRAVIS_BRANCH-$TRAVIS_COMMIT.tgz";
-  pip install --user awscli && cd deb && tar -czf $b *.deb && ~/.local/bin/aws s3
-  cp --acl public-read $b s3://heroku-hsup; fi
+script: godep go test ./... && make deb-local version=$(git describe --tags --always | sed -e 's/^v//') && if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then b="build-$TRAVIS_BRANCH-$TRAVIS_COMMIT.tgz"; pip install --user awscli && cd deb && tar -czf $b *.deb && ~/.local/bin/aws s3 cp --acl public-read $b s3://heroku-hsup; fi
 notifications:
   email: false
   hipchat:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ gosrc          := src/github.com/heroku/hsup
 
 # deb build vars
 packagename    := hsup
-version        := 0.0.10
+version        ?= 0.0.10
 buildpath      := $(shell pwd)/deb
 controldir     := $(buildpath)/DEBIAN
 installpath    := $(buildpath)/usr/bin
@@ -102,4 +102,3 @@ boot2docker-init:
 	boot2docker ssh "sudo sh -c \
 	    'mkdir -p /mnt/sda1/var/lib/hsup && \
 	    ln -sf /mnt/sda1/var/lib/hsup /var/lib/hsup'"
-


### PR DESCRIPTION
Makes it easier to see in, say, `dpkg -l` what version of hsup is being used.