### PR TITLE
libcontainer supports adding an extra network interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,10 @@ deb: all
 	rm -rf $(buildpath)
 
 ftest: hsup-docker-container
-	docker run --privileged \
+	docker run --privileged --cap-add=ALL \
 	    -v /var/run/docker.sock:/run/docker.sock \
 	    -v /var/lib/hsup/stacks:/var/lib/hsup/stacks \
+	    -v /lib/modules:/lib/modules \
 	    --entrypoint="/sbin/hsup-in-docker" hsup sh -c \
 	    'mkdir -p /var/cache/buildpack/go1.4.1/go/src/github.com/heroku/ && \
 	    ln -s /app /var/cache/buildpack/go1.4.1/go/src/github.com/heroku/hsup && \

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Some drivers accept custom configuration via ENV.
 
 * `LIBCONTAINER_DYNO_SUBNET`: a CIDR block to allocate dyno subnets (of size
   /30) from. It is `172.16.0.0/12` (RFC1918) by default when not set.
+* `LIBCONTAINER_DYNO_EXTRA_INTERFACE`: interface on the host to inject into the
+  dyno (currently as a macvlan subinterface), together with its IP address CIDR
+  in the format: `hostIFName:IP/Mask`. Eg.: `eth1:10.0.0.10/24`.
 * `LIBCONTAINER_DYNO_UID_MIN` and `LIBCONTAINER_DYNO_UID_MAX`: Linux UIDs to use
   for each dyno. It also defines the maximum number of allowed dynos, as each
   dyno gets a unique UID per box. To avoid reusing subnets (IPs), make sure that

--- a/ftest/libcontainer_test.go
+++ b/ftest/libcontainer_test.go
@@ -27,6 +27,24 @@ func TestConfigurableLibcontainerDynoSubnet(t *testing.T) {
 	}
 }
 
+func TestExtraInterface(t *testing.T) {
+	onlyWithLibcontainer(t)
+
+	output, err := run(
+		AppMinimal, "", []string{
+			"LIBCONTAINER_DYNO_EXTRA_INTERFACE=eth0:192.168.201.5/24",
+		},
+		`ip -o addr show eth1 | grep -w inet | awk '{print $4}'`,
+	)
+	debug(t, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(output.out.String()) != "192.168.201.5/24" {
+		t.Fatal("Expected an extra (eth1) interface with IP assigned to be: 192.168.201.5/24")
+	}
+}
+
 func TestConfigurableUIDRange(t *testing.T) {
 	onlyWithLibcontainer(t)
 

--- a/libcontainer_network.go
+++ b/libcontainer_network.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io/ioutil"
+	"log"
 	"net"
 
 	"github.com/docker/libnetwork"
@@ -17,7 +18,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const containerIFID = 1
+const (
+	routedIFID  = 1
+	macvlanIFID = 2
+	MTU         = 1500
+	TxQueueLen  = 0
+)
 
 var (
 	ErrInvalidIPMask   = errors.New("mask is not a /30")
@@ -28,7 +34,6 @@ var (
 // Routed implements libnetwork's Driver interface,
 // offering containers only layer 3 connectivity to the outside world.
 type Routed struct {
-	//	network.Veth
 	networks map[string]*routedNetwork
 }
 
@@ -36,10 +41,10 @@ func RegisterRoutedDriver(controller libnetwork.NetworkController) error {
 	r := &Routed{networks: make(map[string]*routedNetwork)}
 	capability := driverapi.Capability{Scope: driverapi.LocalScope}
 	c := controller.(driverapi.DriverCallback)
-	if err := c.RegisterDriver("routed", r, capability); err != nil {
+	if err := c.RegisterDriver(r.Type(), r, capability); err != nil {
 		return err
 	}
-	return controller.ConfigureNetworkDriver("routed", nil)
+	return controller.ConfigureNetworkDriver(r.Type(), nil)
 }
 
 type routedNetwork struct {
@@ -84,7 +89,7 @@ func (r *Routed) CreateEndpoint(
 	if !ok {
 		return ErrInvalidNetwork
 	}
-	name1, name2, err := createVethPair("veth", 0)
+	name1, name2, err := createVethPair("veth", TxQueueLen)
 	if err != nil {
 		return err
 	}
@@ -106,10 +111,10 @@ func (r *Routed) CreateEndpoint(
 			netlink.LinkDel(containerIF)
 		}
 	}()
-	if err := netlink.LinkSetMTU(hostIF, 1500); err != nil {
+	if err := netlink.LinkSetMTU(hostIF, MTU); err != nil {
 		return err
 	}
-	if err := netlink.LinkSetMTU(containerIF, 1500); err != nil {
+	if err := netlink.LinkSetMTU(containerIF, MTU); err != nil {
 		return err
 	}
 
@@ -130,7 +135,7 @@ func (r *Routed) CreateEndpoint(
 	}
 	emptyIPV6 := net.IPNet{}
 	return epInfo.AddInterface(
-		containerIFID,
+		routedIFID,
 		containerIF.Attrs().HardwareAddr,
 		*epSubnet.Host(),
 		emptyIPV6,
@@ -183,7 +188,7 @@ func (r *Routed) Join(
 		return ErrInvalidEndpoint
 	}
 	for _, n := range jinfo.InterfaceNames() {
-		if n.ID() != containerIFID {
+		if n.ID() != routedIFID {
 			continue // find the container interface
 		}
 		if err := n.SetNames(endpoint.containerIFName, "eth"); err != nil {
@@ -242,8 +247,175 @@ func createVethPair(prefix string, txQueueLen int) (string, string, error) {
 	}
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: host, TxQLen: txQueueLen},
-		PeerName:  child}
+		PeerName:  child,
+	}
 	return host, child, netlink.LinkAdd(veth)
+}
+
+// Macvlan implements libnetwork's Driver interface,
+// creating macvlan (type=bridge) subinterfaces for containers
+type Macvlan struct {
+	networks map[string]*macvlanNetwork
+}
+
+func RegisterMacvlanDriver(controller libnetwork.NetworkController) error {
+	d := &Macvlan{networks: make(map[string]*macvlanNetwork)}
+	capability := driverapi.Capability{Scope: driverapi.LocalScope}
+	c := controller.(driverapi.DriverCallback)
+	if err := c.RegisterDriver(d.Type(), d, capability); err != nil {
+		return err
+	}
+	return controller.ConfigureNetworkDriver(d.Type(), nil)
+}
+
+type macvlanNetwork struct {
+	hostIF    string
+	endpoints map[string]*macvlanEndpoint
+}
+
+type macvlanEndpoint struct {
+	containerIFName string
+}
+
+func (d *Macvlan) Config(options map[string]interface{}) error {
+	return nil // noop
+}
+
+func (d *Macvlan) CreateNetwork(nid types.UUID, options map[string]interface{}) error {
+	network := &macvlanNetwork{
+		hostIF:    options["hostIF"].(string),
+		endpoints: make(map[string]*macvlanEndpoint),
+	}
+	d.networks[string(nid)] = network
+	_, err := netlink.LinkByName(network.hostIF) // check if exists
+	return err
+}
+
+func (d *Macvlan) DeleteNetwork(nid types.UUID) error {
+	delete(d.networks, string(nid))
+	return nil
+}
+
+func (d *Macvlan) CreateEndpoint(
+	nid, eid types.UUID,
+	epInfo driverapi.EndpointInfo,
+	options map[string]interface{},
+) error {
+	var err error
+	address := options["address"].(net.IPNet)
+	network, ok := d.networks[string(nid)]
+	if !ok {
+		return ErrInvalidNetwork
+	}
+	subIFName, err := netutils.GenerateIfaceName("mac", 7)
+	if err != nil {
+		return err
+	}
+	hostIF, err := netlink.LinkByName(network.hostIF)
+	if err != nil {
+		return err
+	}
+	subIF := &netlink.Macvlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        subIFName,
+			ParentIndex: hostIF.Attrs().Index,
+			TxQLen:      TxQueueLen,
+		},
+		Mode: netlink.MACVLAN_MODE_BRIDGE,
+	}
+	log.Println("macvlan====> ADDING SUBIF")
+	if err := netlink.LinkAdd(subIF); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			netlink.LinkDel(subIF)
+		}
+	}()
+
+	log.Println("macvlan====> MTU")
+	if err := netlink.LinkSetMTU(subIF, MTU); err != nil {
+		return err
+	}
+	log.Println("macvlan====> IP")
+	if err := netlink.AddrAdd(subIF, &netlink.Addr{
+		IPNet: &address,
+	}); err != nil {
+		return err
+	}
+
+	log.Println("macvlan====> UP")
+	if err := netlink.LinkSetUp(subIF); err != nil {
+		return err
+	}
+	network.endpoints[string(eid)] = &macvlanEndpoint{
+		containerIFName: subIFName,
+	}
+	emptyIPV6 := net.IPNet{}
+	return epInfo.AddInterface(
+		macvlanIFID,
+		subIF.Attrs().HardwareAddr,
+		address,
+		emptyIPV6,
+	)
+}
+
+func (d *Macvlan) DeleteEndpoint(nid, eid types.UUID) error {
+	network, ok := d.networks[string(nid)]
+	if !ok {
+		return ErrInvalidNetwork
+	}
+	endpoint, ok := network.endpoints[string(eid)]
+	if !ok {
+		return nil // already gone
+	}
+	containerIF, err := netlink.LinkByName(endpoint.containerIFName)
+	if err != nil {
+		return nil // already gone
+	}
+	if err := netlink.LinkDel(containerIF); err != nil {
+		return err
+	}
+	delete(network.endpoints, string(eid))
+	return nil
+}
+
+func (d *Macvlan) EndpointOperInfo(nid, eid types.UUID) (map[string]interface{}, error) {
+	return make(map[string]interface{}), nil
+}
+
+func (d *Macvlan) Join(
+	nid, eid types.UUID,
+	sboxKey string,
+	jinfo driverapi.JoinInfo,
+	options map[string]interface{},
+) error {
+	network, ok := d.networks[string(nid)]
+	if !ok {
+		return ErrInvalidNetwork
+	}
+	endpoint, ok := network.endpoints[string(eid)]
+	if !ok {
+		return ErrInvalidEndpoint
+	}
+	for _, n := range jinfo.InterfaceNames() {
+		if n.ID() != macvlanIFID {
+			continue // find the container interface
+		}
+		if err := n.SetNames(endpoint.containerIFName, "eth"); err != nil {
+			return err
+		}
+		return nil
+	}
+	return errors.New("Join: macvlan interface not found")
+}
+
+func (d *Macvlan) Leave(nid, eid types.UUID) error {
+	return nil // noop
+}
+
+func (_ *Macvlan) Type() string {
+	return "macvlan"
 }
 
 // smallSubnet encapsulates operations on single host /30 IPv4 networks. They


### PR DESCRIPTION
the `LIBCONTAINER_DYNO_EXTRA_INTERFACE=hostIF:IP/Mask` env var can be set to make the libcontainer driver add a secondary (eth1) interface to dynos, as a macvlan subinterface (type bridge) of hostIF on the host.