### PR TITLE
Use ipvlan (instead of macvlan) for extra dyno interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ _testmain.go
 *.prof
 
 *.deb
+/deb

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Some drivers accept custom configuration via ENV.
 * `LIBCONTAINER_DYNO_EXTRA_INTERFACE`: interface on the host to inject into the
   dyno (currently as a [ipvlan][ipvlan] subinterface), together with its IP address
   CIDR in the format: `hostIFName:IP/Mask`. Eg.: `eth1:10.0.0.10/24`.
+* `LIBCONTAINER_DYNO_EXTRA_ROUTES`: extra routes to add to the dyno network
+  namespace main routing table. Format: `IP/Mask:Gateway:IF,IP/Mask:Gateway,IF,...`,
+  example: `10.0.0.0/8:10.1.1.1:eth1,192.168.0.0/24:default:eth0`. The special
+  value `default` can be used as the gateway, and will be replaced with the
+  dyno's default route gateway at runtime.
 * `LIBCONTAINER_DYNO_UID_MIN` and `LIBCONTAINER_DYNO_UID_MAX`: Linux UIDs to use
   for each dyno. It also defines the maximum number of allowed dynos, as each
   dyno gets a unique UID per box. To avoid reusing subnets (IPs), make sure that

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Some drivers accept custom configuration via ENV.
 * `LIBCONTAINER_DYNO_SUBNET`: a CIDR block to allocate dyno subnets (of size
   /30) from. It is `172.16.0.0/12` (RFC1918) by default when not set.
 * `LIBCONTAINER_DYNO_EXTRA_INTERFACE`: interface on the host to inject into the
-  dyno (currently as a macvlan subinterface), together with its IP address CIDR
-  in the format: `hostIFName:IP/Mask`. Eg.: `eth1:10.0.0.10/24`.
+  dyno (currently as a [ipvlan][ipvlan] subinterface), together with its IP address
+  CIDR in the format: `hostIFName:IP/Mask`. Eg.: `eth1:10.0.0.10/24`.
 * `LIBCONTAINER_DYNO_UID_MIN` and `LIBCONTAINER_DYNO_UID_MAX`: Linux UIDs to use
   for each dyno. It also defines the maximum number of allowed dynos, as each
   dyno gets a unique UID per box. To avoid reusing subnets (IPs), make sure that
@@ -182,3 +182,4 @@ Some drivers accept custom configuration via ENV.
   `172.17.0.0/16` can provide `2 ** (30-16)` = **16384** subnets of size /30. In
   this case, to avoid subnets being reused, make sure that `(maxUID - minUID) <= 16384`.
 
+[ipvlan]: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvlan.txt

--- a/ftest/libcontainer_test.go
+++ b/ftest/libcontainer_test.go
@@ -73,15 +73,15 @@ func TestExtraInterfaceRoutes(t *testing.T) {
 	output, err := run(
 		AppMinimal, "", []string{
 			"LIBCONTAINER_DYNO_EXTRA_INTERFACE=dummy10:192.168.201.5/24",
-			"LIBCONTAINER_DYNO_EXTRA_ROUTES=1.2.3.0/24:192.168.201.1:eth1,4.3.0.0/16:192.168.201.1:eth1",
+			"LIBCONTAINER_DYNO_EXTRA_ROUTES=1.2.3.0/24:192.168.201.1:eth1,4.3.0.0/16:192.168.201.1:eth1,7.7.7.0/24:default:eth0",
 		},
-		`ip -o route | grep eth1 | grep via | awk '{ print $1, $3 }' | sort`,
+		`default=$(ip -o route | grep default | awk '{ print $3 }'); ip -o route | grep "7.7.7.0/24 via $default" | awk '{ print $1 }'; ip -o route | grep eth1 | grep via | awk '{ print $1, $3 }' | sort`,
 	)
 	debug(t, output)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "1.2.3.0/24 192.168.201.1\n4.3.0.0/16 192.168.201.1"
+	want := "7.7.7.0/24\n1.2.3.0/24 192.168.201.1\n4.3.0.0/16 192.168.201.1"
 	if got := strings.TrimSpace(output.out.String()); got != want {
 		t.Fatalf("got routes %q, wanted %q", got, want)
 	}

--- a/ftest/libcontainer_test.go
+++ b/ftest/libcontainer_test.go
@@ -31,9 +31,30 @@ func TestConfigurableLibcontainerDynoSubnet(t *testing.T) {
 func TestExtraInterface(t *testing.T) {
 	onlyWithLibcontainer(t)
 
+	if out, err := exec.Command(
+		"sh", "-c", "ip link add dev dummy10 type dummy",
+	).CombinedOutput(); err != nil {
+		t.Log(string(out))
+		t.Fatal(err)
+	}
+	if out, err := exec.Command(
+		"sh", "-c", "ip link set up dev dummy10",
+	).CombinedOutput(); err != nil {
+		t.Log(string(out))
+		t.Fatal(err)
+	}
+	defer func() {
+		if out, err := exec.Command(
+			"sh", "-c", "ip link del dev dummy10",
+		).CombinedOutput(); err != nil {
+			t.Log(string(out))
+			t.Fatal(err)
+		}
+	}()
+
 	output, err := run(
 		AppMinimal, "", []string{
-			"LIBCONTAINER_DYNO_EXTRA_INTERFACE=eth0:192.168.201.5/24",
+			"LIBCONTAINER_DYNO_EXTRA_INTERFACE=dummy10:192.168.201.5/24",
 		},
 		`ip -o addr show eth1 | grep -w inet | awk '{print $4}'`,
 	)

--- a/libcontainer_dyno_driver.go
+++ b/libcontainer_dyno_driver.go
@@ -183,14 +183,14 @@ func dynoNetworks(
 		return primary, nil, nil
 	}
 
-	if err := RegisterMacvlanDriver(controller); err != nil {
+	if err := RegisterIPVlanDriver(controller); err != nil {
 		return nil, nil, err
 	}
 	extraIFOpts := libnetwork.NetworkOptionGeneric(map[string]interface{}{
 		"hostIF": extraIFHost,
 	})
 	if extra, err = controller.NewNetwork(
-		"macvlan", "dynosExtra", extraIFOpts,
+		"ipvlan", "dynosExtra", extraIFOpts,
 	); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
ipvlan subinterfaces allows multiple dynos to be attached to the same host interface, and share the same MAC address. This requires a linux kernel with support for ipvlan (3.19+).

Also add support for custom routes to be added inside dynos.